### PR TITLE
Use select to determine what executable definition to use

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,12 @@
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 
 buildifier(name = "buildifier")
+
+alias(
+    name = "shellcheck_tool",
+    visibility = ["//visibility:public"],
+    actual = select({
+        "@bazel_tools//src/conditions:linux_x86_64": "@shellcheck_linux_x86_64//:shellcheck",
+        "@bazel_tools//src/conditions:darwin": "@shellcheck_darwin//:shellcheck",
+    }),
+)

--- a/def.bzl
+++ b/def.bzl
@@ -30,7 +30,7 @@ shellcheck = rule(
     implementation = _impl,
     attrs = {
         "_shellcheck": attr.label(
-            default = Label("@shellcheck"),
+            default = Label("//:shellcheck_tool"),
             allow_single_file = True,
             cfg = "host",
             executable = True,
@@ -46,7 +46,7 @@ shellcheck_test = rule(
             allow_files = True,
         ),
         "_shellcheck": attr.label(
-            default = Label("@shellcheck"),
+            default = Label("//:shellcheck_tool"),
             allow_single_file = True,
             cfg = "host",
             executable = True,

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,33 +1,32 @@
-def _shellcheck_dependencies_impl(repository_ctx):
-    version = "v0.7.1"
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-    arch = "linux.x86_64"
-    sha256 = "64f17152d96d7ec261ad3086ed42d18232fcb65148b44571b564d688269d36c8"
-
-    os_name = repository_ctx.os.name.lower()
-    if os_name.startswith("mac os"):
-        arch = "darwin.x86_64"
-        sha256 = "b080c3b659f7286e27004aa33759664d91e15ef2498ac709a452445d47e3ac23"
-
-    url = "https://github.com/koalaman/shellcheck/releases/download/{version}/shellcheck-{version}.{arch}.tar.xz".format(
-        version = version,
-        arch = arch,
-    )
-
-    repository_ctx.download_and_extract(
-        url = url,
+def _shellcheck_dep(name, version, arch, sha256):
+    http_archive(
+        name = name,
+        build_file_content = """exports_files(["shellcheck"])
+        """,
         sha256 = sha256,
-        stripPrefix = "shellcheck-" + version,
+        strip_prefix = "shellcheck-" + version,
+        urls = [
+            "https://github.com/koalaman/shellcheck/releases/download/{version}/shellcheck-{version}.{arch}.tar.xz".format(
+                version = version,
+                arch = arch,
+            ),
+        ],
     )
 
-    repository_ctx.file(
-        "BUILD",
-        """exports_files(["shellcheck"])""",
-    )
-
-_shellcheck_dependencies = repository_rule(
-    implementation = _shellcheck_dependencies_impl,
-)
 
 def shellcheck_dependencies():
-    _shellcheck_dependencies(name = "shellcheck")
+    _shellcheck_dep(
+        name = "shellcheck_darwin",
+        version = "v0.7.1",
+        arch = "darwin.x86_64",
+        sha256 = "b080c3b659f7286e27004aa33759664d91e15ef2498ac709a452445d47e3ac23",
+    )
+
+    _shellcheck_dep(
+        name = "shellcheck_linux_x86_64",
+        version = "v0.7.1",
+        arch = "linux.x86_64",
+        sha256 = "64f17152d96d7ec261ad3086ed42d18232fcb65148b44571b564d688269d36c8",
+    )


### PR DESCRIPTION
When running on my OSX laptop, for some reason it was always selecting
the Linux binary.  I was looking at trying to fix this by adjusting
the logic, but I have seen other patterns using `select` and a
condition around the target OS/Arch and this feels cleaner to me.

The upstream conditions being depended on are defined here.
https://github.com/bazelbuild/bazel/blob/1c29dff364fd34d7e6158c812cfd6d96f66be747/src/conditions/BUILD#L87-L94