### PR TITLE
chore: include the examples in the release artifact

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,9 @@
-examples
+examples/check_glob/bazel-bin
+examples/check_glob/bazel-out
+examples/check_glob/bazel-testlogs
+examples/check_glob/bazel-optional_attributes
+
+examples/optional_attributes/bazel-bin
+examples/optional_attributes/bazel-out
+examples/optional_attributes/bazel-testlogs
+examples/optional_attributes/bazel-optional_attributes

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,3 +6,8 @@ common --incompatible_strict_action_env
 common --enable_bzlmod
 
 try-import user.bazelrc
+
+# To update these lines, execute 
+# `bazel run @rules_bazel_integration_test//tools:update_deleted_packages`
+build --deleted_packages=examples/check_glob,examples/optional_attributes
+query --deleted_packages=examples/check_glob,examples/optional_attributes

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,6 +1,6 @@
 ---
 bcr_test_module:
-  module_path: "examples/bzlmod"
+  module_path: "examples/check_glob"
   matrix:
     platform: ["debian10", "macos", "ubuntu2004"]
   tasks:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,6 +10,8 @@ filegroup(
         ":def.bzl",
         ":deps.bzl",
         "//internal:distribution",
+        # Needed for BCR registry to run the pre-submit tests
+        "//examples:distribution",
     ],
     visibility = ["//internal/pkg:__pkg__"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_shellcheck",
-    version = "0.2.4",
+    version = "0.0.0",
     compatibility_level = 1,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,4 +17,11 @@ use_repo(
     "shellcheck_windows_x86_64",
 )
 
+# Dev dependencies
+
 bazel_dep(name = "rules_pkg", version = "0.9.1", dev_dependency = True)
+bazel_dep(
+    name = "rules_bazel_integration_test",
+    version = "0.21.0",
+    dev_dependency = True,
+)

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -26,6 +26,8 @@ main() {
     _log "Extracting the tarball into a temporary directory to run examples"
     tar -xvf "$tarball" -C "$TMPDIR"
 
+    pushd $TMPDIR
+
     # Then run examples with the packaged artifacts
     examples=(
         check_glob
@@ -41,6 +43,8 @@ main() {
             ...
         popd
     done
+
+    popd
     _log "Success"
 }
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,0 +1,14 @@
+filegroup(
+    name = "distribution",
+    srcs = glob(
+        [
+            "check_glob/**",
+            "optional_attributes/**",
+        ],
+        exclude = [
+            "**/.gitignore",
+            "**/MODULE.bazel.lock",
+        ],
+    ),
+    visibility = ["//:__pkg__"],
+)


### PR DESCRIPTION
Summary:
- chore: package the examples with the distribution tarball
- chore: set the MODULE.bazel version to 0
