### PR TITLE
Cleanup top level interface

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,11 +1,16 @@
+###############################################################################
+## Bazel Configuration Flags
+##
+## `.bazelrc` is a Bazel configuration file.
+## https://bazel.build/docs/best-practices#bazelrc-file
+###############################################################################
+
 test --test_output=errors
 
 # Fix the excessive rebuilding when using anything that depends on protobuf rules
 # See https://github.com/bazelbuild/buildtools/issues/744
 common --incompatible_strict_action_env
 common --enable_bzlmod
-
-try-import user.bazelrc
 
 # To update these lines, execute
 # `bazel run @rules_bazel_integration_test//tools:update_deleted_packages`
@@ -15,3 +20,26 @@ query --deleted_packages=examples/check_glob,examples/optional_attributes
 # Enable the aspect
 build --aspects=//shellcheck:shellcheck_aspect.bzl%shellcheck_aspect
 build --output_groups=+shellcheck_checks
+
+###############################################################################
+## Incompatibility flags
+###############################################################################
+
+# https://github.com/bazelbuild/bazel/issues/8195
+build --incompatible_disallow_empty_glob=true
+
+# https://github.com/bazelbuild/bazel/issues/12821
+build --nolegacy_external_runfiles
+
+# https://github.com/bazelbuild/bazel/issues/23043.
+build --incompatible_autoload_externally=
+
+###############################################################################
+## Custom user flags
+##
+## This should always be the last thing in the `.bazelrc` file to ensure
+## consistent behavior when setting flags in that file as `.bazelrc` files are
+## evaluated top to bottom.
+###############################################################################
+
+try-import user.bazelrc

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,8 +2,6 @@ filegroup(
     name = "distribution",
     srcs = [
         "BUILD.bazel",
-        "def.bzl",
-        "deps.bzl",
         "CHANGELOG.md",
         "LICENSE",
         "MODULE.bazel",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ bazel run @rules_shellcheck//:shellcheck -- <parameters>
 And you can define a lint target:
 
 ```starlark
-load("@rules_shellcheck//:def.bzl", "shellcheck", "shellcheck_test")
+load("@rules_shellcheck//shellcheck:shellcheck_test.bzl", "shellcheck_test")
 
 shellcheck_test(
     name = "shellcheck_test",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,1 @@
 workspace(name = "rules_shellcheck")
-
-load("//:deps.bzl", "shellcheck_dependencies")
-
-shellcheck_dependencies()

--- a/def.bzl
+++ b/def.bzl
@@ -1,9 +1,0 @@
-"""This file provides all user facing functions.
-"""
-
-load(
-    "//shellcheck:defs.bzl",
-    _shellcheck_test = "shellcheck_test",
-)
-
-shellcheck_test = _shellcheck_test

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,9 +1,0 @@
-"""Provides shellcheck dependencies on all supported platforms:
-- Linux 64-bit and ARM64
-- OSX 64-bit
-"""
-
-# buildifier: disable=bzl-visibility
-load("//shellcheck/internal:extensions.bzl", _shellcheck_dependencies = "shellcheck_dependencies")
-
-shellcheck_dependencies = _shellcheck_dependencies

--- a/examples/check_glob/BUILD.bazel
+++ b/examples/check_glob/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_shellcheck//:def.bzl", "shellcheck_test")
+load("@rules_shellcheck//shellcheck:shellcheck_test.bzl", "shellcheck_test")
 
 shellcheck_test(
     name = "shellcheck_all",

--- a/examples/optional_attributes/BUILD.bazel
+++ b/examples/optional_attributes/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_shellcheck//:def.bzl", "shellcheck_test")
+load("@rules_shellcheck//shellcheck:shellcheck_test.bzl", "shellcheck_test")
 
 shellcheck_test(
     name = "shellcheck_all",

--- a/internal/pkg/BUILD.bazel
+++ b/internal/pkg/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//:def.bzl", "shellcheck_test")
+load("//shellcheck:shellcheck_test.bzl", "shellcheck_test")
 
 pkg_files(
     name = "files",


### PR DESCRIPTION
This change is purely optional. It deletes the previous interfaces and treats `//shellcheck` as the go-to package following common practices in many other `rules_*` repositories.