### PR TITLE
Fix executable permissions in release artifact

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,15 @@ filegroup(
     visibility = ["//internal/pkg:__pkg__"],
 )
 
+filegroup(
+    name = "executable_distribution",
+    srcs = [
+        "//examples:executable_distribution",
+        "//shellcheck:executable_distribution",
+    ],
+    visibility = ["//internal/pkg:__pkg__"],
+)
+
 alias(
     name = "release",
     actual = "//internal/pkg:release",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -8,7 +8,17 @@ filegroup(
         exclude = [
             "**/.gitignore",
             "**/MODULE.bazel.lock",
+            "optional_attributes/script.sh",
         ],
     ),
+    visibility = ["//:__pkg__"],
+)
+
+# See //shellcheck/internal:executable_distribution — packaged with
+# mode 0755 so extraction preserves the executable bit these
+# example scripts have in the source tree.
+filegroup(
+    name = "executable_distribution",
+    srcs = ["optional_attributes/script.sh"],
     visibility = ["//:__pkg__"],
 )

--- a/internal/pkg/BUILD.bazel
+++ b/internal/pkg/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files", "strip_prefix")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//:def.bzl", "shellcheck_test")
@@ -11,9 +11,22 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(),
 )
 
+# pkg_files defaults to mode 0644, which drops the executable bit
+# on scripts like shellcheck/internal/aspect_runner.sh that are
+# invoked as executables at runtime. Package them separately at 0755.
+pkg_files(
+    name = "executable_files",
+    srcs = [
+        "//:executable_distribution",
+    ],
+    attributes = pkg_attributes(mode = "0755"),
+    strip_prefix = strip_prefix.from_root(),
+)
+
 pkg_tar(
     name = "tar",
     srcs = [
+        ":executable_files",
         ":files",
     ],
     out = "rules_shellcheck.tar",

--- a/shellcheck/BUILD.bazel
+++ b/shellcheck/BUILD.bazel
@@ -15,6 +15,12 @@ filegroup(
     visibility = ["//:__pkg__"],
 )
 
+filegroup(
+    name = "executable_distribution",
+    srcs = ["//shellcheck/internal:executable_distribution"],
+    visibility = ["//:__pkg__"],
+)
+
 toolchain_type(
     name = "toolchain_type",
     visibility = ["//visibility:public"],

--- a/shellcheck/internal/BUILD.bazel
+++ b/shellcheck/internal/BUILD.bazel
@@ -1,6 +1,18 @@
 filegroup(
     name = "distribution",
-    srcs = glob(["*"]),
+    srcs = glob(
+        ["*"],
+        exclude = ["aspect_runner.sh"],
+    ),
+    visibility = ["//shellcheck:__pkg__"],
+)
+
+# Split out so //internal/pkg can package these with mode 0755;
+# aspect_runner.sh is invoked as the executable of ctx.actions.run
+# and must be +x when consumed from the release tarball.
+filegroup(
+    name = "executable_distribution",
+    srcs = ["aspect_runner.sh"],
     visibility = ["//shellcheck:__pkg__"],
 )
 


### PR DESCRIPTION
Some scripts now live in the repo and need to be executable to work on unix systems. This change fixes these permissions in the release artifact.